### PR TITLE
Initialize JSON with JSON

### DIFF
--- a/Sources/JSON/JSON.swift
+++ b/Sources/JSON/JSON.swift
@@ -27,7 +27,11 @@ public enum JSON:
         }
         set {
             guard case var .dictionary(dict) = self else { return }
-            dict[key] = newValue
+            if let newValue {
+                dict[key] = newValue
+            } else {
+                dict.removeValue(forKey: key)
+            }
             self = .dictionary(dict)
         }
     }
@@ -616,7 +620,6 @@ private extension Any? {
         case let e as NSNumber where e.isBool: return .boolean(e.boolValue)
         case let e as NSNumber: return .number(e.doubleValue)
         case let e as String: return .string(e)
-
         // The above cases should catch everything, but, in case they
         // don't, we try remaining types here.
         case let e as Bool: return .boolean(e)
@@ -633,7 +636,7 @@ private extension Any? {
         case let e as UInt16: return .number(Double(e))
         case let e as UInt32: return .number(Double(e))
         case let e as UInt64: return .number(Double(e))
-
+        case let e as JSON: return e
         default: return nil
         }
     }

--- a/Sources/JSON/JSON.swift
+++ b/Sources/JSON/JSON.swift
@@ -620,6 +620,7 @@ private extension Any? {
         case let e as NSNumber where e.isBool: return .boolean(e.boolValue)
         case let e as NSNumber: return .number(e.doubleValue)
         case let e as String: return .string(e)
+
         // The above cases should catch everything, but, in case they
         // don't, we try remaining types here.
         case let e as Bool: return .boolean(e)
@@ -636,7 +637,9 @@ private extension Any? {
         case let e as UInt16: return .number(Double(e))
         case let e as UInt32: return .number(Double(e))
         case let e as UInt64: return .number(Double(e))
+
         case let e as JSON: return e
+
         default: return nil
         }
     }

--- a/Tests/JSONTests/JSONTests.swift
+++ b/Tests/JSONTests/JSONTests.swift
@@ -305,4 +305,38 @@ final class JSONTests: XCTestCase {
 
         XCTAssertEqual(JSON.string("😊"), "😊")
     }
+
+    func testInitWithMixedTypesIncludingJSON() throws {
+        let mixed = [
+            "one": 1,
+            "two": 2.0,
+            "a": "a",
+            "b": JSON.string("b"),
+            "array": [
+                10, true, JSON.null, JSON.boolean(false),
+            ],
+            "json_array": JSON.array([
+                .number(10), .boolean(true), .null, .boolean(false),
+            ]),
+            "dictionary": [
+                "z": "Z",
+                "true": JSON.boolean(true),
+                "true2": true,
+                "number": 123.0,
+            ],
+            "json_dictionary": JSON.dictionary([
+                "z": .string("Z"),
+                "true": .boolean(true),
+                "true2": .boolean(true),
+                "number": .number(123.0),
+            ]),
+        ]
+
+        let json = JSON(mixed)
+
+        guard case let .dictionary(dict) = json else {
+            return XCTFail()
+        }
+        XCTAssertEqual(dict, mixed)
+    }
 }


### PR DESCRIPTION
Previously, we were unable to initialize nested `JSON` types with `JSON`. So, for example, trying to initialize an array of `JSON` types inside of a dictionary would fail because `[JSON]` couldn't be coerced into `[JSON]` because the `json` accessor didn't check if self was already `JSON`. This pull request fixes that issue.